### PR TITLE
feat: extend webapp endpoints

### DIFF
--- a/contrib/README.rst
+++ b/contrib/README.rst
@@ -27,6 +27,10 @@ Quick Start
    venv $ ./contrib/labgrid-webapp
    INFO:     Available routes:
    INFO:       - /labgrid/graph
+   INFO:       - /labgrid/resources
+   INFO:       - /labgrid/places
+   INFO:       - /labgrid/places/{name}/acquire
+   INFO:       - /labgrid/places/{name}/release
    INFO:     Started server process [2378028]
    INFO:     Waiting for application startup.
    INFO:     Application startup complete.
@@ -39,5 +43,12 @@ installation. See http://graphviz.org/download/
 By default the application will start on port 8800.
 
 To see the graph, go to http://0.0.0.0:8800/labgrid/graph
+
+Other endpoints provide coordinator data and basic control:
+
+- http://0.0.0.0:8800/labgrid/resources
+- http://0.0.0.0:8800/labgrid/places
+- POST http://0.0.0.0:8800/labgrid/places/{name}/acquire
+- POST http://0.0.0.0:8800/labgrid/places/{name}/release
 
 See http://0.0.0.0:8800/docs for more information on available endpoints.

--- a/contrib/labgrid-webapp
+++ b/contrib/labgrid-webapp
@@ -7,12 +7,14 @@ import sys
 from typing import Dict
 
 import graphviz
+import grpc
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import Response
 
 from labgrid.remote.client import ClientSession, start_session
 from labgrid.remote.common import Place
+from labgrid.remote.generated import labgrid_coordinator_pb2
 from labgrid.resource import Resource
 from labgrid.util.proxy import proxymanager
 
@@ -113,6 +115,46 @@ def main():
         '''Show a graph of the current infrastructure.'''
         svg = await do_graph(session)
         return Response(content=svg, media_type='image/svg+xml')
+
+    @app.get('/labgrid/resources')
+    async def list_resources() -> Dict[str, Dict]:
+        '''Return all resources known to the coordinator.'''
+        await session.sync_with_coordinator()
+        return session.resources
+
+    @app.get('/labgrid/places')
+    async def list_places() -> Dict[str, Dict]:
+        '''Return all places known to the coordinator.'''
+        await session.sync_with_coordinator()
+        return {
+            name: {
+                'acquired': place.acquired,
+                'tags': place.tags,
+            }
+            for name, place in session.places.items()
+        }
+
+    @app.post('/labgrid/places/{name}/acquire')
+    async def acquire_place(name: str):
+        '''Acquire the specified place.'''
+        request = labgrid_coordinator_pb2.AcquirePlaceRequest(placename=name)
+        try:
+            await session.stub.AcquirePlace(request)
+            await session.sync_with_coordinator()
+        except grpc.aio.AioRpcError as exc:
+            raise HTTPException(status_code=400, detail=exc.details()) from exc
+        return {'status': 'acquired', 'place': name}
+
+    @app.post('/labgrid/places/{name}/release')
+    async def release_place(name: str):
+        '''Release the specified place.'''
+        request = labgrid_coordinator_pb2.ReleasePlaceRequest(placename=name)
+        try:
+            await session.stub.ReleasePlace(request)
+            await session.sync_with_coordinator()
+        except grpc.aio.AioRpcError as exc:
+            raise HTTPException(status_code=400, detail=exc.details()) from exc
+        return {'status': 'released', 'place': name}
 
     parser = argparse.ArgumentParser(
         description='Labgrid webapp',


### PR DESCRIPTION
## Summary
- expand contrib webapp with endpoints for listing resources and places
- allow acquiring and releasing places via HTTP
- document new routes in contrib README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pexpect')*
- `pip install pexpect` *(fails: Could not find a version that satisfies the requirement pexpect)*

------
https://chatgpt.com/codex/tasks/task_e_6899d7ca15c8832f85d6d956c835018c